### PR TITLE
Only pass through non undef values.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -299,7 +299,7 @@ define firewall_multi (
         uid                          =>  $uid,
         week_days                    =>  $week_days,
         zone                         =>  $zone,
-      }
+      }.filter |$_key, $val| { $val =~ NotUndef }
     }
   )
 


### PR DESCRIPTION
This will prevent parameters that have been removed upstream to immediately break firewall_multi.