### PR TITLE
Add failing CI smoke test

### DIFF
--- a/spec/functions/firewall_multi_spec.rb
+++ b/spec/functions/firewall_multi_spec.rb
@@ -35,4 +35,8 @@ describe "firewall_multi" do
       expect(subject.execute(input)).to eq output
     end
   end
+
+  it "intentionally fails to test AI build failure analysis" do
+    expect("build failure analysis smoke test").to eq "passing CI"
+  end
 end


### PR DESCRIPTION
Add an intentionally failing RSpec example on a throwaway branch so the AI build failure analysis workflow can be tested against a simple, obvious CI failure.